### PR TITLE
Fix compilation issues with stricter rules

### DIFF
--- a/msgpack11.cpp
+++ b/msgpack11.cpp
@@ -99,23 +99,23 @@ void dump_data(const T value, std::ostream& os)
 }
 
 inline void dump(NullStruct, std::ostream& os) {
-    os.put(0xc0);
+    os.put(static_cast<char>(0xc0));
 }
 
 inline void dump(float value, std::ostream& os) {
-    os.put(0xca);
+    os.put(static_cast<char>(0xca));
     dump_data(value, os);
 }
 
 inline void dump(double value, std::ostream& os) {
-    os.put(0xcb);
+    os.put(static_cast<char>(0xcb));
     dump_data(value, os);
 }
 
 inline void dump(uint8_t value, std::ostream& os) {
     if(128 <= value)
     {
-        os.put(0xcc);
+        os.put(static_cast<char>(0xcc));
     }
     os.put(value);
 }
@@ -127,7 +127,7 @@ inline void dump(uint16_t value, std::ostream& os) {
     }
     else
     {
-        os.put(0xcd);
+        os.put(static_cast<char>(0xcd));
         dump_data(value, os);
     }
 }
@@ -139,7 +139,7 @@ inline void dump(uint32_t value, std::ostream& os) {
     }
     else
     {
-        os.put(0xce);
+        os.put(static_cast<char>(0xce));
         dump_data(value, os);
     }
 }
@@ -151,7 +151,7 @@ inline void dump(uint64_t value, std::ostream& os) {
     }
     else
     {
-        os.put(0xcf);
+        os.put(static_cast<char>(0xcf));
         dump_data(value, os);
     }
 }
@@ -159,7 +159,7 @@ inline void dump(uint64_t value, std::ostream& os) {
 inline void dump(int8_t value, std::ostream& os) {
     if( value < -32 )
     {
-        os.put(0xd0);
+        os.put(static_cast<char>(0xd0));
     }
     os.put(value);
 }
@@ -167,7 +167,7 @@ inline void dump(int8_t value, std::ostream& os) {
 inline void dump(int16_t value, std::ostream& os) {
     if( value < -(1 << 7) )
     {
-        os.put(0xd1);
+        os.put(static_cast<char>(0xd1));
         dump_data(value, os);
     }
     else if( value <= 0 )
@@ -183,7 +183,7 @@ inline void dump(int16_t value, std::ostream& os) {
 inline void dump(int32_t value, std::ostream& os) {
     if( value < -(1 << 15) )
     {
-        os.put(0xd2);
+        os.put(static_cast<char>(0xd2));
         dump_data(value, os);
     }
     else if( value <= 0 )
@@ -199,7 +199,7 @@ inline void dump(int32_t value, std::ostream& os) {
 inline void dump(int64_t value, std::ostream& os) {
     if( value < -(1LL << 31) )
     {
-        os.put(0xd3);
+        os.put(static_cast<char>(0xd3));
         dump_data(value, os);
     }
     else if( value <= 0 )
@@ -226,17 +226,17 @@ inline void dump(const std::string& value, std::ostream& os) {
     }
     else if(len <= 0xff)
     {
-        os.put(0xd9);
+        os.put(static_cast<char>(0xd9));
         os.put(static_cast<uint8_t>(len));
     }
     else if(len <= 0xffff)
     {
-        os.put(0xda);
+        os.put(static_cast<char>(0xda));
         dump_data(static_cast<uint16_t>(len), os);
     }
     else if(len <= 0xffffffff)
     {
-        os.put(0xdb);
+        os.put(static_cast<char>(0xdb));
         dump_data(static_cast<uint32_t>(len), os);
     }
     else
@@ -258,12 +258,12 @@ inline void dump(const MsgPack::array& value, std::ostream& os) {
     }
     else if(len <= 0xffff)
     {
-        os.put(0xdc);
+        os.put(static_cast<char>(0xdc));
         dump_data(static_cast<uint16_t>(len), os);
     }
     else if(len <= 0xffffffff)
     {
-        os.put(0xdd);
+        os.put(static_cast<char>(0xdd));
         dump_data(static_cast<uint32_t>(len), os);
     }
     else
@@ -285,12 +285,12 @@ inline void dump(const MsgPack::object& value, std::ostream& os) {
     }
     else if(len <= 0xffff)
     {
-        os.put(0xde);
+        os.put(static_cast<char>(0xde));
         dump_data(static_cast<uint16_t>(len), os);
     }
     else if(len <= 0xffffffff)
     {
-        os.put(0xdf);
+        os.put(static_cast<char>(0xdf));
         dump_data(static_cast<uint32_t>(len), os);
     }
     else
@@ -308,17 +308,17 @@ inline void dump(const MsgPack::binary& value, std::ostream& os) {
     size_t const len = value.size();
     if(len <= 0xff)
     {
-        os.put(0xc4);
+        os.put(static_cast<char>(0xc4));
         dump_data(static_cast<uint8_t>(len), os);
     }
     else if(len <= 0xffff)
     {
-        os.put(0xc5);
+        os.put(static_cast<char>(0xc5));
         dump_data(static_cast<uint16_t>(len), os);
     }
     else if(len <= 0xffffffff)
     {
-        os.put(0xc6);
+        os.put(static_cast<char>(0xc6));
         dump_data(static_cast<uint32_t>(len), os);
     }
     else
@@ -334,30 +334,30 @@ inline void dump(const MsgPack::extension& value, std::ostream& os) {
     const size_t len = data.size();
 
     if(len == 0x01) {
-        os.put(0xd4);
+        os.put(static_cast<char>(0xd4));
     }
     else if(len == 0x02) {
-        os.put(0xd5);
+        os.put(static_cast<char>(0xd5));
     }
     else if(len == 0x04) {
-        os.put(0xd6);
+        os.put(static_cast<char>(0xd6));
     }
     else if(len == 0x08) {
-        os.put(0xd7);
+        os.put(static_cast<char>(0xd7));
     }
     else if(len == 0x10) {
-        os.put(0xd8);
+        os.put(static_cast<char>(0xd8));
     }
     else if(len <= 0xff) {
-        os.put(0xc7);
+        os.put(static_cast<char>(0xc7));
         os.put(static_cast<uint8_t>(len));
     }
     else if(len <= 0xffff) {
-        os.put(0xc8);
+        os.put(static_cast<char>(0xc8));
         dump_data(static_cast<uint16_t>(len), os);
     }
     else if(len <= 0xffffffff) {
-        os.put(0xc9);
+        os.put(static_cast<char>(0xc9));
         dump_data(static_cast<uint32_t>(len), os);
     }
     else {

--- a/msgpack11.hpp
+++ b/msgpack11.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <vector>
 #include <map>


### PR DESCRIPTION
Hello! We are using your library in the IXWebSocket project. We had some manual patches done on top of msgpack11 so that it properly compiles with -Werror -Wpedantic and newer compilers like GCC 15.

We would like to upstream those changes.

Original commit credits go to the following commits:
https://github.com/machinezone/IXWebSocket/commit/e965322a98f4464b55400185f15ff4769ac5ffd4
https://github.com/machinezone/IXWebSocket/commit/8115594483b958c6db809dd3edb1603c3969f591

Thanks!